### PR TITLE
Fix segfault due to uninitialised mem_manager->file_name

### DIFF
--- a/src/system/mm.c
+++ b/src/system/mm.c
@@ -176,6 +176,8 @@ mm_t* mm_bulk_malloc(const uint64_t num_bytes,const bool init_mem) {
     mem_manager->mode = MM_READ_WRITE;
     mem_manager->allocated = num_bytes;
     mem_manager->cursor = mem_manager->memory;
+    mem_manager->fd = -1;
+    mem_manager->file_name = NULL;
     // MM_PRINT_MEM_ALIGMENT(mem_manager->memory); // Debug
     return mem_manager;
   } else { // Resort to MMAP in disk


### PR DESCRIPTION
`mm_bulk_malloc()` wasn't setting `mem_manager->file_name`, leading to crashes when this was passed to `free()` as the program was cleaning up its allocations.  Fix by ensuring it's set to `NULL`.

The uninitialised value was detected by `valgrind` as shown:
```
==2359059== Thread 4:
==2359059== Conditional jump or move depends on uninitialised value(s)
==2359059==    at 0x14B34F: mm_bulk_free (mm.c:285)
==2359059==    by 0x14DEB5: mm_slab_delete (mm_slab.c:117)
==2359059==    by 0x14750E: matches_delete (matches.c:88)
==2359059==    by 0x13B4B3: mapper_se_thread (mapper.c:212)
==2359059==    by 0x4A1AAC2: start_thread (pthread_create.c:442)
==2359059==    by 0x4AABA03: clone (clone.S:100)
==2359059==  Uninitialised value was created by a heap allocation
==2359059==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2359059==    by 0x14C3A3: mm_malloc_ (mm.c:141)
==2359059==    by 0x14C3A3: mm_bulk_malloc (mm.c:173)
==2359059==    by 0x14DBE4: mm_slab_add_new_segment (mm_slab.c:60)
==2359059==    by 0x14DD91: mm_slab_new_ (mm_slab.c:109)
==2359059==    by 0x14738C: matches_new (matches.c:47)
==2359059==    by 0x13B3ED: mapper_se_thread (mapper.c:161)
==2359059==    by 0x4A1AAC2: start_thread (pthread_create.c:442)
==2359059==    by 0x4AABA03: clone (clone.S:100)
==2359059==
```